### PR TITLE
Select checkpoints to enable or disable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,8 @@ Metrics/MethodLength:
 
 Style/Documentation:
   Enabled: false
+Style/GuardClause:
+  Enabled: false
 Style/HashEachMethods:
   Enabled: true
 Style/HashTransformKeys:

--- a/README.md
+++ b/README.md
@@ -217,6 +217,29 @@ Cutoff.wrap(3) do
 end
 ```
 
+Selecting Checkpoints
+---------------------------
+
+In some cases, you may want to select some checkpoints to use, but not others.
+For example, you may want to run some code that contains MySQL queries, but not
+use the mysql2 patch. The `exclude` and `only` options support this.
+
+```ruby
+Cutoff.wrap(10, exclude: :mysql2) do
+  # The mysql2 patch won't be used here
+end
+
+Cutoff.wrap(10, only: %i[foo bar]) do
+  # These checkpoints will be used
+  Cutoff.checkpoint!(:foo)
+  Cutoff.checkpoint!(:bar)
+
+  # These checkpoints will be skipped
+  Cutoff.checkpoint!(:asdf)
+  Cutoff.checkpoint!
+end
+```
+
 Timing a Rails Controller
 ---------------------------
 

--- a/lib/cutoff/patch/net_http.rb
+++ b/lib/cutoff/patch/net_http.rb
@@ -4,6 +4,9 @@ require 'net/http'
 
 class Cutoff
   module Patch
+    # Set checkpoints for Ruby HTTP requests. Also sets the Net::HTTP timeouts
+    # to the remaining cutoff time. You can select this patch with
+    # `exclude` or `only` using the checkpoint name `:net_http`.
     module NetHttp
       def self.gen_timeout_method(name)
         <<~RUBY
@@ -23,13 +26,13 @@ class Cutoff
       # @see Net::HTTP#start
       module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
         def start
-          if (cutoff = Cutoff.current)
+          if (cutoff = Cutoff.current) && cutoff.selected?(:net_http)
             remaining = cutoff.seconds_remaining
             #{gen_timeout_method('open_timeout')}
             #{gen_timeout_method('read_timeout')}
             #{gen_timeout_method('write_timeout') if use_write_timeout?}
             #{gen_timeout_method('continue_timeout')}
-            Cutoff.checkpoint!
+            Cutoff.checkpoint!(:net_http)
           end
           super
         end

--- a/lib/cutoff/sidekiq.rb
+++ b/lib/cutoff/sidekiq.rb
@@ -17,9 +17,10 @@ class Cutoff
     #     end
     #   end
     class ServerMiddleware
-      # @param [Object] worker the worker instance
-      # @param [Hash] job the full job payload
-      # @param [String] queue the name of the queue the job was pulled from
+      # @param worker [Object] the worker instance
+      # @param _job [Hash] the full job payload
+      # @param _queue [String] queue the name of the queue the job was pulled
+      #   from
       # @yield the next middleware in the chain or worker `perform` method
       # @return [void]
       def call(worker, _job, _queue)

--- a/spec/patch/mysql2_spec.rb
+++ b/spec/patch/mysql2_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe 'Cutoff::Patch::Mysql2', if: defined?(Mysql2) do
     client.query('SELECT 1 FROM dual')
   end
 
+  it 'does nothing if excluded' do
+    expect(client).to receive(:_query)
+      .with('SELECT 1 FROM dual', any_args)
+    Timecop.freeze
+    Cutoff.wrap(3, exclude: :mysql2) do
+      client.query('SELECT 1 FROM dual')
+    end
+  end
+
   it 'does nothing for insert if there is time remaining' do
     expect(client).to receive(:_query)
       .with("INSERT users(first_name) VALUES('Bob')", any_args)

--- a/spec/patch/net_http_spec.rb
+++ b/spec/patch/net_http_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe Cutoff::Patch::NetHttp do
     end.to raise_error(Cutoff::CutoffExceededError)
   end
 
+  it 'does nothing if excluded' do
+    Timecop.freeze
+    Cutoff.start(2, exclude: :net_http)
+    Timecop.freeze(3)
+    expect(Net::HTTP.get_response(URI.parse('http://example.com')).code)
+      .to eq('200')
+  end
+
   it 'sets timeouts to remaining seconds during start' do
     Timecop.freeze
     Cutoff.start(5)
@@ -30,6 +38,15 @@ RSpec.describe Cutoff::Patch::NetHttp do
     Net::HTTP.start(uri.host, uri.port, read_timeout: 1) do |http|
       expect(http.read_timeout).to eq(1)
     end
+  end
+
+  it 'does not set timeouts if excluded' do
+    Timecop.freeze
+    Cutoff.start(5, exclude: :net_http)
+    Timecop.freeze(2)
+    http = Net::HTTP.new(URI.parse('http://example.com'))
+    expect(http.open_timeout).to eq(60)
+    expect(http.read_timeout).to eq(60)
   end
 
   it 'sets write timeout for ruby >=2.6' do


### PR DESCRIPTION
Add `exclude` and `only` options when creating a Cutoff to select named checkpoints to use.