### PR TITLE
Change CutoffExceededError to inherit from Timeout::Error

### DIFF
--- a/lib/cutoff.rb
+++ b/lib/cutoff.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal:true
 
 require 'set'
+require 'timeout'
 
 require 'cutoff/version'
 require 'cutoff/error'

--- a/lib/cutoff/error.rb
+++ b/lib/cutoff/error.rb
@@ -2,7 +2,7 @@
 
 class Cutoff
   # The Cutoff base error class
-  class CutoffError < StandardError
+  module CutoffError
     private
 
     def message_with_meta(message, **meta)
@@ -15,7 +15,9 @@ class Cutoff
   end
 
   # Raised by {Cutoff#checkpoint!} if the time has been exceeded
-  class CutoffExceededError < CutoffError
+  class CutoffExceededError < Timeout::Error
+    include CutoffError
+
     attr_reader :cutoff
 
     def initialize(cutoff)


### PR DESCRIPTION
This allows generic timeout rescue handlers to act as expected.