### PR TITLE
Use CLOCK_MONOTONIC instead of CLOCK_MONOTONIC_RAW

### DIFF
--- a/lib/cutoff/timer.rb
+++ b/lib/cutoff/timer.rb
@@ -2,18 +2,17 @@
 
 class Cutoff
   module Timer
-    if defined?(Process::CLOCK_MONOTONIC_RAW)
-      # The current time
+    if defined?(Process::CLOCK_MONOTONIC)
+      # The current relative time
       #
       # If it is available, this will use a monotonic clock. This is a clock
-      # that always moves forward in time. If that is not available on this
-      # system, `Time.now` will be used
+      # that always moves forward in time and starts at an arbitrary point
+      # (such as system startup time). If that is not available on this system,
+      # `Time.now` will be used.
       #
-      # @return [Float] The current time as a float
-      def now
-        Process.clock_gettime(Process::CLOCK_MONOTONIC_RAW)
-      end
-    elsif defined?(Process::CLOCK_MONOTONIC)
+      # This does not represent current real time
+      #
+      # @return [Float] The current relative time as a float
       def now
         Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end

--- a/spec/cutoff_spec.rb
+++ b/spec/cutoff_spec.rb
@@ -227,36 +227,21 @@ RSpec.describe Cutoff do
       load './lib/cutoff/timer.rb'
     end
 
-    it 'gets CLOCK_MONOTONIC_RAW if available' do
-      unless defined?(Process::CLOCK_MONOTONIC_RAW)
-        skip 'CLOCK_MONOTONIC_RAW now available to test'
-      end
-
+    before do
+      hide_const('Process::CLOCK_MONOTONIC_RAW')
       Cutoff::Timer.send(:remove_method, :now)
       load './lib/cutoff/timer.rb'
-      expect(Process).to receive(:clock_gettime)
-        .with(Process::CLOCK_MONOTONIC_RAW)
-
-      Cutoff.now
     end
 
-    context 'when CLOCK_MONOTONIC_RAW is not available' do
-      before do
-        hide_const('Process::CLOCK_MONOTONIC_RAW')
-        Cutoff::Timer.send(:remove_method, :now)
-        load './lib/cutoff/timer.rb'
+    it 'gets CLOCK_MONOTONIC if available' do
+      unless defined?(Process::CLOCK_MONOTONIC)
+        skip 'CLOCK_MONOTONIC now available to test'
       end
 
-      it 'gets CLOCK_MONOTONIC if available' do
-        unless defined?(Process::CLOCK_MONOTONIC)
-          skip 'CLOCK_MONOTONIC now available to test'
-        end
+      expect(Process).to receive(:clock_gettime)
+        .with(Process::CLOCK_MONOTONIC)
 
-        expect(Process).to receive(:clock_gettime)
-          .with(Process::CLOCK_MONOTONIC)
-
-        Cutoff.now
-      end
+      Cutoff.now
     end
 
     context 'when CLOCK_MONOTONIC is not available' do


### PR DESCRIPTION
The raw monotonic clock is not adjusted for drift whereas the normal
version is. This could cause inaccuracies with measurement. The normal
monotonic clock is typically more accurate.