### PR TITLE
Pull value from job, not worker

### DIFF
--- a/lib/cutoff/sidekiq.rb
+++ b/lib/cutoff/sidekiq.rb
@@ -25,7 +25,7 @@ class Cutoff
       # @yield the next middleware in the chain or worker `perform` method
       # @return [void]
       def call(_worker, job, _queue)
-        allowed_seconds = job["cutoff"]
+        allowed_seconds = job['cutoff']
         return yield if allowed_seconds.nil?
 
         Cutoff.wrap(allowed_seconds) { yield }

--- a/lib/cutoff/sidekiq.rb
+++ b/lib/cutoff/sidekiq.rb
@@ -18,14 +18,14 @@ class Cutoff
     #     end
     #   end
     class ServerMiddleware
-      # @param worker [Object] the worker instance
-      # @param _job [Hash] the full job payload
+      # @param _worker [Object] the worker instance
+      # @param job [Hash] the full job payload
       # @param _queue [String] queue the name of the queue the job was pulled
       #   from
       # @yield the next middleware in the chain or worker `perform` method
       # @return [void]
-      def call(worker, _job, _queue)
-        allowed_seconds = worker.class.sidekiq_options['cutoff']
+      def call(_worker, job, _queue)
+        allowed_seconds = job["cutoff"]
         return yield if allowed_seconds.nil?
 
         Cutoff.wrap(allowed_seconds) { yield }


### PR DESCRIPTION
By pulling the value from the job data, not the worker class, we allow the user to override the value dynamically, e.g.

```ruby
class MyJob
  include Sidekiq::Job
  sidekiq_options cutoff: 4.5
```

```ruby
MyJob.set(cutoff: 3.0).perform_async(...) # dynamically change value
```