### PR TITLE
Switch CI to support jruby and truffleruby head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, jruby-9.2.19, truffleruby-21.1.0]
+        ruby: [2.5, 2.6, 2.7, 3.0, jruby-head, truffleruby-head]
         bundler: [default]
         include:
           - ruby: '2.3'


### PR DESCRIPTION
Using pinned versions results in occasional manual work, or CI failures. We only really support head anyway.