### PR TITLE
Apply Net::HTTP cutoff to internal retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-12
+
+### Fixed
+
+- Net::HTTP patch now also re-applies on `begin_transport`, so internal retries
+  (Net::HTTP retries idempotent requests once by default on transient errors
+  like Net::ReadTimeout) respect the cutoff instead of silently doubling the
+  effective deadline.
+
 ## [1.0.0] - 2026-05-12
 
 This release marks Cutoff's API as stable. There are no behavior changes
@@ -98,7 +107,8 @@ to `Timeout::Error`. `CutoffError` changes from a class to a module.
 - Cutoff class
 - Mysql2 patch
 
-[Unreleased]: https://github.com/justinhoward/cutoff/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/justinhoward/cutoff/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/justinhoward/cutoff/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/justinhoward/cutoff/compare/v0.5.2...v1.0.0
 [0.5.2]: https://github.com/justinhoward/cutoff/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/justinhoward/cutoff/compare/v0.5.0...v0.5.1

--- a/lib/cutoff/patch/net_http.rb
+++ b/lib/cutoff/patch/net_http.rb
@@ -25,21 +25,42 @@ class Cutoff
       end
 
       # Same as the original start, but adds a checkpoint for starting HTTP
-      # requests and sets network timeouts to the remaining time
+      # requests and sets network timeouts to the remaining time.
+      #
+      # Also applies the same logic to begin_transport, which is called on
+      # every HTTP attempt including internal retries. Net::HTTP#transport_request
+      # silently retries idempotent requests (GET, HEAD, PUT, DELETE, OPTIONS,
+      # TRACE) up to max_retries (default 1) on transient errors like
+      # Net::ReadTimeout. Without re-applying the cutoff in begin_transport,
+      # the retry path goes through #connect (not #start), reuses the original
+      # read_timeout, and effectively doubles the deadline you set.
       #
       # @method start
+      # @method begin_transport
       # @see Net::HTTP#start
+      # @see Net::HTTP#begin_transport
       module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
         def start
-          if (cutoff = Cutoff.current) && cutoff.selected?(:net_http)
-            remaining = cutoff.seconds_remaining
-            #{gen_timeout_method('open_timeout')}
-            #{gen_timeout_method('read_timeout')}
-            #{gen_timeout_method('write_timeout') if use_write_timeout?}
-            #{gen_timeout_method('continue_timeout')}
-            Cutoff.checkpoint!(:net_http)
-          end
+          _cutoff_apply_to_net_http
           super
+        end
+
+        def begin_transport(req)
+          _cutoff_apply_to_net_http
+          super
+        end
+
+        private
+
+        def _cutoff_apply_to_net_http
+          return unless (cutoff = Cutoff.current) && cutoff.selected?(:net_http)
+
+          remaining = cutoff.seconds_remaining
+          #{gen_timeout_method('open_timeout')}
+          #{gen_timeout_method('read_timeout')}
+          #{gen_timeout_method('write_timeout') if use_write_timeout?}
+          #{gen_timeout_method('continue_timeout')}
+          Cutoff.checkpoint!(:net_http)
         end
       RUBY
     end

--- a/lib/cutoff/version.rb
+++ b/lib/cutoff/version.rb
@@ -3,6 +3,6 @@
 class Cutoff
   # @return [Gem::Version] The current version of the cutoff gem
   def self.version
-    Gem::Version.new('1.0.0')
+    Gem::Version.new('1.1.0')
   end
 end

--- a/spec/patch/net_http_spec.rb
+++ b/spec/patch/net_http_spec.rb
@@ -71,4 +71,61 @@ RSpec.describe Cutoff::Patch::NetHttp do
     expect(Net::HTTP.get_response(URI.parse('https://example.com')).code)
       .to eq('200')
   end
+
+  describe "Net::HTTP's internal retry of idempotent requests" do
+    # Establishes the upstream behavior the cutoff patch is guarding against:
+    # Net::HTTP#transport_request silently retries idempotent requests
+    # (default max_retries: 1) on Net::ReadTimeout and other transient errors,
+    # which can effectively double the deadline a caller set on the request.
+    it 'normally retries the request once on Net::ReadTimeout' do
+      uri = URI.parse('https://example.com')
+      Net::HTTP.start(uri.host, uri.port) do |http|
+        req = Net::HTTP::Get.new('/')
+        attempts = 0
+        allow(req).to receive(:exec) do
+          attempts += 1
+          raise Net::ReadTimeout
+        end
+
+        expect { http.request(req) }.to raise_error(Net::ReadTimeout)
+        expect(attempts).to eq(2)
+      end
+    end
+
+    it 'tightens read_timeout on each retry as the cutoff is consumed' do
+      Timecop.freeze
+      Cutoff.start(10)
+      uri = URI.parse('https://example.com')
+      Net::HTTP.start(uri.host, uri.port) do |http|
+        req = Net::HTTP::Get.new('/')
+        timeouts = []
+        allow(req).to receive(:exec) do
+          timeouts << http.read_timeout
+          Timecop.freeze(4)
+          raise Net::ReadTimeout
+        end
+
+        expect { http.request(req) }.to raise_error(Net::ReadTimeout)
+        expect(timeouts).to eq([10, 6])
+      end
+    end
+
+    it 'short-circuits the retry with CutoffExceededError when the cutoff is exhausted' do
+      Timecop.freeze
+      Cutoff.start(5)
+      uri = URI.parse('https://example.com')
+      Net::HTTP.start(uri.host, uri.port) do |http|
+        req = Net::HTTP::Get.new('/')
+        attempts = 0
+        allow(req).to receive(:exec) do
+          attempts += 1
+          Timecop.freeze(10)
+          raise Net::ReadTimeout
+        end
+
+        expect { http.request(req) }.to raise_error(Cutoff::CutoffExceededError)
+        expect(attempts).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Net::HTTP#transport_request silently retries idempotent requests (GET, HEAD, PUT, DELETE, OPTIONS, TRACE) up to max_retries (default 1) on transient errors like Net::ReadTimeout, OpenSSL::SSL::SSLError, and Errno::ECONNRESET. The retry path closes the socket and goes through re-apply: the retry inherited the read_timeout set on the original attempt. A deadline of N seconds silently became 2N seconds, with no log line or callback to indicate the retry had happened.

Factor the timeout-clamping and checkpoint into a private helper and also call it from begin_transport, which runs once per HTTP attempt including retries. On a retry after the cutoff is exhausted, the checkpoint raises CutoffExceededError; Net::HTTP catches it as a Timeout::Error and re-raises once max_retries is hit. With the default max_retries of 1, the second attempt short-circuits cleanly.

As a side effect, the keep-alive connection-reuse path now also applies the cutoff. Previously a request reusing a pooled socket skipped the start patch entirely, since #start is only called when opening a new connection.