### PR TITLE
Release v1.0.0: modernize CI matrix and raise Ruby floor to 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', jruby-head, truffleruby-head]
+        ruby: ['3.1', '3.2', '3.3', '3.4', jruby-head, truffleruby-head]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
-        env:
-          REDIS_VERSION: ${{ matrix.redis }}
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -29,8 +27,8 @@ jobs:
         env:
           MYSQL_USER: root
           MYSQL_PASSWORD: root
-      - uses: codecov/codecov-action@v3
-        if: matrix.ruby == '3.0'
+      - uses: codecov/codecov-action@v4
+        if: matrix.ruby == '3.4'
         with:
           files: coverage/coverage.xml
       - run: bin/check-version
@@ -38,20 +36,20 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.4'
           bundler-cache: true
       - run: bundle exec rubocop
 
   yard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.4'
           bundler-cache: true
       - run: bin/yardoc --fail-on-warning
 
@@ -59,10 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.4'
           bundler-cache: true
       - run: bin/check-version
 
@@ -71,7 +69,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Publish to RubyGems
         run: |
           mkdir -p $HOME/.gem

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 3.1
 
 Gemspec/DeprecatedAttributeAssignment: { Enabled: true }
 Gemspec/RequireMFA: { Enabled: true }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-12
+
+This release marks Cutoff's API as stable. There are no behavior changes
+since 0.5.2.
+
+### Breaking
+
+- Drop support for Ruby < 3.1. The minimum supported Ruby is now 3.1.
+  `required_ruby_version` in the gemspec has been raised accordingly. #21
+  justinhoward
+
+### Changed
+
+- Modernize CI matrix to Ruby 3.1, 3.2, 3.3, 3.4, jruby-head, and
+  truffleruby-head, and update gem dependencies that had rotted out of
+  CI in the interim. #21 justinhoward
+
 ## [0.5.2] - 2022-09-06
 
 ### Changed
@@ -81,7 +98,8 @@ to `Timeout::Error`. `CutoffError` changes from a class to a module.
 - Cutoff class
 - Mysql2 patch
 
-[Unreleased]: https://github.com/justinhoward/cutoff/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/justinhoward/cutoff/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/justinhoward/cutoff/compare/v0.5.2...v1.0.0
 [0.5.2]: https://github.com/justinhoward/cutoff/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/justinhoward/cutoff/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/justinhoward/cutoff/compare/v0.4.2...v0.5.0

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,9 @@ gemspec
 # here. This also allows us to use conditional dependencies that depend on the
 # platform
 
-not_jruby = %i[ruby mingw x64_mingw].freeze
+not_jruby = %i[ruby windows].freeze
 
 gem 'actionpack'
-gem 'bundler', '>= 1.17', '< 3'
 gem 'byebug', platforms: not_jruby
 gem 'irb', '~> 1.0'
 # Minimum of 0.5.0 for specific error classes
@@ -25,9 +24,11 @@ gem 'yard', '~> 0.9.25', platforms: not_jruby
 
 gem 'concurrent-ruby'
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
-  gem 'rubocop', '1.34.1'
-  gem 'rubocop-rspec', '2.12'
-  gem 'simplecov', '~> 0.21.0'
-  gem 'simplecov-cobertura', '~> 2.1'
-end
+gem 'rubocop', '1.34.1'
+gem 'rubocop-rspec', '2.12'
+gem 'simplecov', '~> 0.21.0'
+gem 'simplecov-cobertura', '~> 3.1'
+
+# simplecov-cobertura crashes with REXML::ParseException: Malformed XML on
+# rexml >= 3.4.2. https://github.com/jessebs/simplecov-cobertura/issues/48
+gem 'rexml', '< 3.4.2'

--- a/cutoff.gemspec
+++ b/cutoff.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['lib/**/*.rb', '*.md', '*.txt', '.yardopts']
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'rspec-rails', '~> 5.0'

--- a/lib/cutoff/version.rb
+++ b/lib/cutoff/version.rb
@@ -3,6 +3,6 @@
 class Cutoff
   # @return [Gem::Version] The current version of the cutoff gem
   def self.version
-    Gem::Version.new('0.5.2')
+    Gem::Version.new('1.0.0')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,11 +27,7 @@ require 'rspec/rails'
 require 'sidekiq/testing'
 
 begin
-  # We don't test Mysql2 on Ruby 2.3 since that would require
-  # installing an old EOL version of OpenSSL
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
-    require 'cutoff/patch/mysql2'
-  end
+  require 'cutoff/patch/mysql2'
 rescue LoadError
   # Ok if mysql2 isn't available
 end


### PR DESCRIPTION
## Summary

Tags this release as **v1.0.0** to mark Cutoff's API as stable. The only user-visible change since 0.5.2 is the Ruby >= 3.1 floor introduced here, which is breaking under SemVer. The Net::HTTP retry fix (#20) is intentionally held back for v1.1.0.

## CI rot diagnosed (and what fixes it)

The CI matrix hadn't run on master since April 2023 (`16e2bb2 Split CI into multiple jobs`) and the gem ecosystem had since dropped support for the older Rubies it covered. As of #20 every job was red on PRs for reasons unrelated to the PR itself.

| Matrix entry | Failure | Fix in this PR |
|---|---|---|
| Ruby 2.3, 2.4 | bundler resolved `loofah 2.21.x` against Rails 5.2; loofah 2.21 needs `Nokogiri::HTML4` (only in nokogiri >= 1.14, requires Ruby 2.6+) | Drop from matrix |
| Ruby 2.5, 2.6 | `activesupport 6.1` + `concurrent-ruby >= 1.3.5` raises `uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger` (concurrent-ruby stopped pulling in stdlib `Logger`) | Drop from matrix |
| Ruby 2.7 | All 69 specs pass, then `simplecov-cobertura 2.1.0` crashes with `REXML::ParseException: Malformed XML: No root element` on `rexml >= 3.4.2` and fails the job | Drop from matrix; bump `simplecov-cobertura` to `~> 3.1` (jessebs/simplecov-cobertura#44) and pin `rexml < 3.4.2` for the still-open regression on 3.4.3+ (jessebs/simplecov-cobertura#48) for the surviving Rubies |
| Ruby 3.0 | Same as 2.7 plus: ships with bundler 2.2.x, which predates the `:windows` platform token (added in bundler 2.4, December 2022). EOL since March 2024. | Drop from matrix |
| jruby-head, truffleruby-head | Both ship bundler 4.x; `gem 'bundler', '>= 1.17', '< 3'` aborts the install before any spec runs | Remove the `gem 'bundler'` line - bundler is environmental, not a runtime dep |

## Other changes

- New matrix: `['3.1', '3.2', '3.3', '3.4']` + `jruby-head`, `truffleruby-head`
- `cutoff.gemspec`: `required_ruby_version` `>= 2.3` → `>= 3.1`
- `.rubocop.yml`: `TargetRubyVersion` `2.3` → `3.1` (caught by rubocop's `Gemspec/RequiredRubyVersion` cop)
- Codecov upload moves from `matrix.ruby == '3.0'` to `matrix.ruby == '3.4'`
- `rubocop` / `yard` / `check_version` jobs move to Ruby 3.4
- `actions/checkout@v3` → `@v4`, `codecov/codecov-action@v3` → `@v4`
- Replace deprecated `:mingw, :x64_mingw` platform tokens with `:windows`
- Drop the `if RUBY_VERSION >= 2.6` guard around the rubocop/simplecov gems (always true now)
- Drop the Ruby 2.4 mysql2 guard in `spec/spec_helper.rb` (always true now)

## Release commit

Second commit (`Release v1.0.0`) bumps `lib/cutoff/version.rb` to `1.0.0` and adds the `[1.0.0] - 2026-05-12` section to `CHANGELOG.md` with `### Breaking` calling out the Ruby floor change. Tag will be pushed manually after merge.

## Test plan

Verified locally on Ruby 3.3.7:

- [x] `bundle install` resolves cleanly (`simplecov-cobertura 3.1.0`, `rexml 3.3.5`, `actionpack 7.2.0`, no `bundler` in DEPENDENCIES)
- [x] `bundle exec rspec` - 57/66 pass; the 9 failures are environmental (sandbox blocks outbound HTTP for Net::HTTP specs, no MySQL daemon for mysql2 specs) and unrelated to these changes
- [x] `CI=1 bundle exec rspec spec/cutoff_spec.rb` - simplecov-cobertura formatter writes `coverage/coverage.xml` cleanly with no REXML parse error
- [x] `bundle exec rubocop` - clean
- [x] `bin/yardoc --fail-on-warning` - 100% documented, no warnings
- [x] `ruby -r ./lib/cutoff/version -e "puts Cutoff.version"` prints `1.0.0` (so `bin/check-version` will accept the `v1.0.0` tag)

CI on this PR exercises the full matrix.